### PR TITLE
지식 중복 시 DB·Notion 조회수 동기화, 쇼츠 링크 저장, 요약 품질 개선

### DIFF
--- a/app/repositories/knowledge.py
+++ b/app/repositories/knowledge.py
@@ -225,6 +225,7 @@ async def update_summary_result_to_db(
                 "knowledge_id": str(knowledge.id),
                 "category_id": category.id,
                 "category_name": category.name,
+                "hit_count": knowledge.hit_count,
             }
         except Exception:
             await session.rollback()

--- a/app/schemas/graph_state.py
+++ b/app/schemas/graph_state.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 class IntelligenceState(TypedDict):
     """UPLOAD 파이프라인 — LangGraph 노드 간 공유 상태"""
     video_id: str             # Step 1 (입력) — 라우터에서 추출한 영상 ID
+    metadata: dict            # Step 1 — 영상 제목/채널명 등 메타데이터
     chunks: list              # Step 1 — 자막 추출+청킹 결과 (collect_and_chunk)
     summarized_chunks: list   # Step 2 노드1 — 청크별 요약 (summarize_each_chunk)
     embeddings: list          # Step 2 노드2 — 요약문 벡터화 (embed_summaries_node)
@@ -50,8 +51,19 @@ DEFAULT_CATEGORIES = [
 # ==========================================
 class VideoOverview(BaseModel):
     """전체 개요 생성 시 OpenAI가 반환해야 하는 구조"""
-    title: str = Field(description="영상의 핵심 주제를 나타내는 제목 (15자 이내)")
-    full_summary: str = Field(description="영상 전체 내용을 3~5문장으로 요약")
+    title: str = Field(
+        description=(
+            "원본 영상 제목을 그대로 복사하지 않고, 영상의 핵심 인물과 쟁점을 "
+            "내용 중심으로 요약한 새 제목 (25자 이내)"
+        )
+    )
+    full_summary: str = Field(
+        description=(
+            "영상을 보지 않아도 핵심 흐름을 이해할 수 있도록 사건 배경, "
+            "주요 주장, 근거, 쟁점을 압축해 담은 3~5문장의 핵심 요약. "
+            "재판 관련 영상이면 피고인 등 법적 지위를 이름과 함께 포함"
+        )
+    )
     category: str = Field(
         description=(
             "영상의 카테고리. 가능하면 다음 11개 중 하나로 분류할 것: "

--- a/app/services/intelligence_service.py
+++ b/app/services/intelligence_service.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import functools
 import logging
 import uuid
 
@@ -21,6 +22,7 @@ openai_client = get_openai_sdk_client()
 _chunk_summary_llm = get_llm()
 
 _overview_chain = None
+_MIN_FULL_SUMMARY_LENGTH = 250
 
 
 def _get_overview_chain():
@@ -30,18 +32,134 @@ def _get_overview_chain():
     return _overview_chain
 
 
-def _process_single_chunk(chunk):
+def _build_chunk_context_block(metadata: dict | None) -> str:
+    metadata = metadata or {}
+    video_title = (
+        metadata.get("video_title") or metadata.get("title") or ""
+    ).strip()
+    channel_name = (metadata.get("channel_name") or "").strip()
+
+    if not video_title and not channel_name:
+        return ""
+
+    lines = ["[영상 컨텍스트]"]
+    if video_title:
+        lines.append(f"- 영상 제목: {video_title}")
+    if channel_name:
+        lines.append(f"- 채널명: {channel_name}")
+    lines.append(
+        "위 제목/채널명에 등장하는 인물·사건·기관이 본 영상의 화자 또는 주제일 "
+        "가능성이 높다. 청크 본문에서 대명사·일반 명칭으로만 지칭되더라도, "
+        "위 컨텍스트와 명확히 매칭될 때는 해당 실제 이름/직책으로 표기하라."
+    )
+    return "\n".join(lines)
+
+
+def _build_legal_role_hint(metadata: dict | None, content: str) -> str:
+    metadata = metadata or {}
+    video_title = metadata.get("video_title") or metadata.get("title") or ""
+    legal_role_markers = ("피고인", "변호인", "재판부", "공소장", "재판")
+    if not any(marker in content for marker in legal_role_markers):
+        return ""
+    if not video_title:
+        return ""
+
+    return (
+        "[법적 지위 힌트]\n"
+        f"청크 본문에 재판/법적 지위 단서가 있고, 영상 제목은 '{video_title}'이다. "
+        "본문의 '피고인' 같은 법적 지위는 생략하지 말고, 영상 제목의 핵심 인물명과 결합해 "
+        "'피고인 [인물명]' 형태로 요약에 포함하라."
+    )
+
+
+_CHUNK_SYSTEM_PROMPT = (
+    "너는 유튜브 영상 텍스트 조각을 요약하는 AI다. "
+    "핵심 인사이트와 정보 중심으로 2~3문장으로 간결하게 한국어로 요약한다. "
+    "불필요한 인트로, 인사, 광고 문구는 제외한다. "
+    "자막 오류나 중복 표현은 의미를 유지하면서 자연스럽게 정리한다. "
+    "예: '군사망 사망 사건'은 '군 사망 사건' 또는 '군내 사망 사건'으로 쓴다.\n\n"
+    "[화자·인물 표기 규칙 — 반드시 따름]\n"
+    "1. 다음 일반 명칭의 단독 사용을 금지한다: '피고인', '발언자', '화자', "
+    "'그', '그녀', '이 사람', '한 인물', '관계자', '당사자'. "
+    "원문에 이런 표현이 있어도 그대로 옮기지 말고, 가능한 한 실제 인명·직책·기관명과 결합한다. "
+    "단, 법적 지위가 핵심 맥락이면 삭제하지 말고 '피고인 윤석열 전 대통령'처럼 이름과 함께 보존한다.\n"
+    "2. 제공된 [영상 컨텍스트]의 영상 제목·채널명에 인물명/직책/사건명이 "
+    "있다면 그것을 화자 또는 주제 인물로 우선 사용한다.\n"
+    "3. 청크 본문에 '피고인', '변호인', '재판부', '공소장'처럼 재판 맥락 단서가 있고 "
+    "영상 컨텍스트에 핵심 인물명이 있으면, 법적 지위와 인물명을 결합해 표기한다. "
+    "예: '피고인이 발언했다'가 아니라 '피고인 윤석열 전 대통령이 발언했다'.\n"
+    "4. 청크 본문 안에 인명·직책·기관명·사건명이 명시되어 있으면 익명화·일반화하지 말고 "
+    "그 표현을 그대로 보존한다.\n"
+    "5. 컨텍스트와 본문 모두 인물을 특정할 단서가 전혀 없는 경우에 한해, "
+    "'화자' 등 중립적 명칭을 최소한으로 사용한다. 법적 지위는 근거가 있을 때만 이름과 함께 쓴다."
+)
+
+
+def _expand_full_summary_if_needed(
+    *,
+    title: str,
+    full_summary: str,
+    overview_input: str,
+) -> str:
+    if len((full_summary or "").strip()) >= _MIN_FULL_SUMMARY_LENGTH:
+        return full_summary
+
     try:
         response = _chunk_summary_llm.invoke(
             [
                 SystemMessage(
                     content=(
-                        "너는 유튜브 영상 텍스트 조각을 요약하는 AI다. "
-                        "핵심 인사이트와 정보 중심으로 2~3문장으로 간결하게 요약한다. "
-                        "불필요한 인트로, 인사, 광고 문구는 제외한다."
+                        "너는 유튜브 영상 요약문을 상세하게 보강하는 AI다. "
+                        "입력으로 제공된 영상 제목, 채널명, 청크별 요약, 초안 요약만 근거로 사용한다. "
+                        "없는 사실을 추가하지 말고, 이미 있는 정보를 더 구체적이고 읽기 쉽게 확장한다. "
+                        "결과는 한국어 문단 하나로 작성하고, 3~5문장, 250~450자 분량으로 작성한다. "
+                        "사건 배경, 핵심 인물, 주요 주장, 근거, 쟁점을 압축해서 포함한다. "
+                        "재판 관련 영상이면 당사자의 법적 지위(피고인, 변호인, 증인 등)를 이름과 함께 포함한다. "
+                        "초안이나 원본 정보에 '피고인 [이름]' 표현이 있으면 첫 문장에 반드시 보존한다."
                     ),
                 ),
-                HumanMessage(content=chunk["content"]),
+                HumanMessage(
+                    content=(
+                        f"요약 제목: {title}\n\n"
+                        f"초안 요약:\n{full_summary}\n\n"
+                        f"원본 정보:\n{overview_input}\n\n"
+                        "위 정보만 바탕으로 full_summary에 들어갈 3~5문장 요약문을 다시 작성해줘."
+                    )
+                ),
+            ]
+        )
+        expanded = base_message_text(response)
+        if expanded:
+            return expanded
+    except Exception as exc:
+        logger.warning(f"  summary expansion failed: {exc}")
+
+    return full_summary
+
+
+def _process_single_chunk(
+    chunk,
+    context_block: str = "",
+    metadata: dict | None = None,
+):
+    content = chunk.get("content", "")
+    user_message_parts = []
+    if context_block:
+        user_message_parts.append(context_block)
+    legal_role_hint = _build_legal_role_hint(
+        metadata,
+        content,
+    )
+    if legal_role_hint:
+        user_message_parts.append(legal_role_hint)
+    user_message_parts.append("[청크 본문]\n" + content)
+    user_message = "\n\n".join(user_message_parts)
+
+    try:
+        response = _chunk_summary_llm.invoke(
+            [
+                SystemMessage(content=_CHUNK_SYSTEM_PROMPT),
+                HumanMessage(content=user_message),
             ],
         )
         summary = base_message_text(response)
@@ -59,14 +177,21 @@ def _process_single_chunk(chunk):
 def summarize_each_chunk(state: IntelligenceState) -> dict:
     video_id = state.get("video_id", "Unknown")
     chunks = state.get("chunks", [])
+    metadata = state.get("metadata") or {}
+
+    context_block = _build_chunk_context_block(metadata)
 
     logger.info(
         f"[LangGraph: chunk summary] start (video_id={video_id}, chunks={len(chunks)})"
     )
     # 완료 시점은 summarized_chunks 반환 후 info로 찍힘 (아래 return 이후 불가 → 호출자에서 처리)
 
+    chunk_runner = functools.partial(
+        _process_single_chunk, context_block=context_block, metadata=metadata
+    )
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        results = executor.map(_process_single_chunk, chunks)
+        results = executor.map(chunk_runner, chunks)
         summarized_chunks = list(results)
 
     return {"summarized_chunks": summarized_chunks}
@@ -109,10 +234,19 @@ def embed_summaries_node(state: IntelligenceState) -> dict:
 def generate_overview(state: IntelligenceState) -> dict:
     video_id = state.get("video_id", "Unknown")
     summarized_chunks = state.get("summarized_chunks", [])
+    metadata = state.get("metadata") or {}
+    video_title = metadata.get("video_title") or metadata.get("title") or "Unknown"
+    channel_name = metadata.get("channel_name") or "Unknown"
 
     all_summaries = "\n".join(
         f"[{chunk.get('chunk_order', '?')}] {chunk.get('summary', '')}"
         for chunk in summarized_chunks
+    )
+    overview_input = (
+        f"영상 제목: {video_title}\n"
+        f"채널명: {channel_name}\n"
+        f"영상 ID: {video_id}\n\n"
+        f"청크별 요약:\n{all_summaries}"
     )
 
     logger.info(f"[LangGraph: overview] start (video_id={video_id})")
@@ -123,12 +257,45 @@ def generate_overview(state: IntelligenceState) -> dict:
                 SystemMessage(
                     content=(
                         "아래는 유튜브 영상의 청크별 요약 목록이다. "
-                        "내용을 종합해 영상 전체 제목, 전체 요약, 카테고리를 생성한다. "
+                        "영상 제목과 채널명을 함께 참고해 핵심 인물, 사건, 맥락을 보존한다. "
+                        "내용을 종합해 새 요약 제목, 핵심 요약, 카테고리를 생성한다. "
+                        "최종 요약에는 누가, 어떤 상황에서, 무엇을 주장하거나 설명했는지 포함한다.\n\n"
+                        "[요약 제목 생성 규칙 — 반드시 따름]\n"
+                        "- 입력의 '영상 제목'은 인물명과 사건 맥락을 파악하기 위한 참고 자료일 뿐이다.\n"
+                        "- title 필드에는 원본 영상 제목을 그대로 복사하지 말고, 청크 요약의 핵심 내용을 바탕으로 새 제목을 만든다.\n"
+                        "- '분노', '자폭', '충격', '무슨 일', '술렁이는', '놀란'처럼 클릭을 유도하는 감정적 표현은 제거한다.\n"
+                        "- title은 핵심 인물 + 사건/쟁점 + 발언/주장을 드러내는 정보형 제목이어야 한다.\n"
+                        "- 예: 원본 제목이 '분노한 윤석열, 분노 못참다 자폭...'이라도 "
+                        "title은 '윤석열 군 사망사건 수사권 주장'처럼 작성한다.\n\n"
+                        "[핵심 요약 작성 규칙 — 반드시 따름]\n"
+                        "- full_summary는 제목을 길게 풀어쓴 수준이 아니라, 영상을 보지 않아도 핵심 흐름을 이해할 수 있는 요약이어야 한다.\n"
+                        "- 반드시 3~5문장으로 작성하고, 가능하면 250~450자 분량으로 압축해서 작성한다.\n"
+                        "- 사건 배경, 핵심 인물, 주요 발언/주장, 근거, 쟁점을 포함하되 불필요한 반복은 제거한다.\n"
+                        "- 법률, 정치, 뉴스, 재판 관련 영상이면 관련 법/제도, 사건명, 쟁점, 책임 소재를 빠뜨리지 않는다.\n"
+                        "- 재판 관련 영상이면 누가 피고인/변호인/증인인지, 어떤 사건이나 혐의 맥락에서 발언했는지 포함한다.\n"
+                        "- 청크 요약에 '피고인 윤석열 전 대통령'처럼 법적 지위와 이름이 함께 나온 경우, "
+                        "full_summary 첫 문장에 그 표현을 반드시 보존한다.\n"
+                        "- 추상적인 표현만 반복하지 말고, 청크 요약에 나온 구체적 내용을 우선 반영한다.\n"
+                        "- 단순히 '중요성을 강조했다', '논의가 이루어졌다'처럼 끝내지 말고 무엇을 왜 강조했는지 설명한다.\n"
+                        "- 자막 오류나 중복 표현은 의미를 유지하면서 자연스럽게 정리한다. "
+                        "예: '군사망 사망 사건'은 '군 사망 사건' 또는 '군내 사망 사건'으로 쓴다.\n"
+                        "- 5문장을 넘기지 않는다.\n\n"
+                        "[화자·인물 표기 규칙 — 반드시 따름]\n"
+                        "- 다음 일반 명칭의 단독 사용을 금지한다: '피고인', '발언자', '화자', "
+                        "'그', '그녀', '이 사람', '한 인물', '관계자', '당사자'. "
+                        "다만 법적 지위가 핵심 맥락이면 '피고인 윤석열 전 대통령'처럼 이름과 함께 쓴다.\n"
+                        "- 영상 제목·채널명에 인물명/직책/사건명이 명시되어 있다면 "
+                        "그것을 화자나 핵심 인물로 우선 표기한다.\n"
+                        "- 청크 요약에 '피고인' 등 일반 명칭이 남아 있으면, 영상 제목/채널명과 "
+                        "맥락을 종합해 '피고인 윤석열 전 대통령'처럼 실제 인명·직책을 붙여 최종 요약을 작성한다.\n"
+                        "- 이미 청크 요약에 '피고인 [인물명]' 형태가 있다면, 최종 요약에서 법적 지위를 삭제하지 않는다.\n"
+                        "- 단서가 전혀 없는 경우에 한해 '화자' 같은 중립 명칭을 최소한으로 쓴다. "
+                        "법적 지위는 근거가 있을 때만 이름과 함께 쓴다.\n\n"
                         "요약은 Notion 페이지에 게시할 예정이므로 깔끔하고 읽기 쉽게 작성한다. "
                         "카테고리는 영상의 형식이 아니라 핵심 주제로 분류한다."
                     ),
                 ),
-                HumanMessage(content=all_summaries),
+                HumanMessage(content=overview_input),
             ],
         )
         if isinstance(overview, dict):
@@ -136,6 +303,11 @@ def generate_overview(state: IntelligenceState) -> dict:
         title = overview.title
         full_summary = overview.full_summary
         category = overview.category
+        full_summary = _expand_full_summary_if_needed(
+            title=title,
+            full_summary=full_summary,
+            overview_input=overview_input,
+        )
     except Exception as exc:
         logger.warning(f"  overview generation failed: {exc}")
         title = f"영상 {video_id}"
@@ -177,6 +349,7 @@ class IntelligenceService:
                 "title": "",
                 "full_summary": "",
                 "category": "",
+                "metadata": data.get("metadata") or {},
             },
             config=RunnableConfig(run_id=run_id),
         )

--- a/app/services/knowledge_pipeline.py
+++ b/app/services/knowledge_pipeline.py
@@ -182,11 +182,14 @@ class KnowledgePipelineService:
 
         notion_page = None
         if user_id:
+            hit_count = db_result.get("hit_count", 1) if db_result else 1
             notion_page = save_summary_to_user_notion(
                 user_id=user_id,
                 video_id=video_id,
                 title=title,
                 full_summary=full_summary,
+                category=resolved_category,
+                hit_count=hit_count,
             )
             # 유사 영상 검색 — FIND_SIMILAR 의도(include_similar=True)일 때만 실행
             # UPLOAD 의도는 자동 호출하지 않음
@@ -228,6 +231,7 @@ def save_summary_to_user_notion(
     title: str,
     full_summary: str,
     category: str | None = None,
+    hit_count: int | None = 1,
 ) -> dict[str, Any] | None:
     db = SessionLocal()
     try:
@@ -243,6 +247,7 @@ def save_summary_to_user_notion(
             summary=full_summary or "Summary is empty.",
             source_url=f"https://www.youtube.com/watch?v={video_id}",
             category=category,
+            hit_count=hit_count,
         )
         if page is None:
             notion_logger.info(
@@ -251,7 +256,11 @@ def save_summary_to_user_notion(
             return None
 
         notion_logger.info(f"Summary page saved: {page.get('url')}")
-        return {"id": page.get("id"), "url": page.get("url")}
+        return {
+            "id": page.get("id"),
+            "url": page.get("url"),
+            "action": page.get("_a_ka_action"),
+        }
     except NotionServiceError as exc:
         notion_logger.warning(
             "Notion API error (user_id=%s status=%s): %s",

--- a/app/services/notion_connection_service.py
+++ b/app/services/notion_connection_service.py
@@ -263,9 +263,15 @@ def ensure_summary_database(
                 connection.summary_data_source_id = fresh_ds
                 db.commit()
                 db.refresh(connection)
+            _ensure_summary_database_configuration(
+                service, connection, raise_errors=raise_errors
+            )
             return connection
 
     if connection.summary_data_source_id:
+        _ensure_summary_database_configuration(
+            service, connection, raise_errors=raise_errors
+        )
         return connection
 
     try:
@@ -338,7 +344,54 @@ def ensure_summary_database(
     connection.summary_data_source_id = data_source_id
     db.commit()
     db.refresh(connection)
+    _ensure_summary_database_configuration(
+        service, connection, raise_errors=raise_errors
+    )
     return connection
+
+
+def _ensure_summary_database_configuration(
+    service: NotionService,
+    connection: NotionConnection,
+    *,
+    raise_errors: bool,
+) -> None:
+    if not connection.summary_data_source_id:
+        return
+
+    try:
+        service.ensure_summary_database_schema(connection.summary_data_source_id)
+    except NotionServiceError as exc:
+        logger.warning(
+            "Could not ensure Notion summary database schema. "
+            "user_id=%s data_source_id=%s status=%s: %s",
+            connection.user_id,
+            connection.summary_data_source_id,
+            exc.status_code,
+            exc,
+        )
+        if raise_errors:
+            raise
+        return
+
+    if not connection.summary_database_id:
+        return
+
+    try:
+        service.ensure_hit_count_sorted_view(
+            database_id=connection.summary_database_id,
+            data_source_id=connection.summary_data_source_id,
+        )
+    except NotionServiceError as exc:
+        logger.warning(
+            "Could not ensure Notion hit-count sorted view. "
+            "user_id=%s database_id=%s data_source_id=%s status=%s: %s",
+            connection.user_id,
+            connection.summary_database_id,
+            connection.summary_data_source_id,
+            exc.status_code,
+            exc,
+        )
 
 
 def find_duplicate_notion_owner_connection(
@@ -453,6 +506,7 @@ def create_summary_page_for_user(
     summary: str,
     source_url: str | None = None,
     category: str | None = None,
+    hit_count: int | None = 1,
 ) -> dict[str, Any] | None:
     connection = get_notion_connection(db, user_id)
     if connection is None:
@@ -466,6 +520,7 @@ def create_summary_page_for_user(
             summary=summary,
             source_url=source_url,
             category=category,
+            hit_count=hit_count,
         )
     except NotionServiceError as exc:
         if exc.status_code == 404:
@@ -483,6 +538,7 @@ def create_summary_page_for_user(
                 summary=summary,
                 source_url=source_url,
                 category=category,
+                hit_count=hit_count,
             )
 
         if exc.status_code != 401 or not connection.refresh_token:
@@ -498,6 +554,7 @@ def create_summary_page_for_user(
             summary=summary,
             source_url=source_url,
             category=category,
+            hit_count=hit_count,
         )
     except NotionServiceError as exc:
         if exc.status_code != 404:
@@ -517,6 +574,7 @@ def create_summary_page_for_user(
             summary=summary,
             source_url=source_url,
             category=category,
+            hit_count=hit_count,
         )
 
 
@@ -527,18 +585,63 @@ def _create_summary_database_item_for_connection(
     summary: str,
     source_url: str | None,
     category: str | None,
+    hit_count: int | None,
 ) -> dict[str, Any] | None:
     connection = ensure_summary_database(db, connection, raise_errors=True)
     if not connection.summary_data_source_id:
         return None
 
-    return NotionService(api_key=connection.access_token).create_summary_database_item(
+    service = NotionService(api_key=connection.access_token)
+    if source_url:
+        existing_pages = service.find_summary_database_items_by_source_url(
+            connection.summary_data_source_id,
+            source_url,
+        )
+        if existing_pages:
+            existing_page = existing_pages[0]
+            page_id = existing_page.get("id")
+            if page_id and hit_count is not None:
+                updated_page = service.update_summary_database_item_hit_count(
+                    page_id,
+                    hit_count,
+                )
+                _archive_duplicate_summary_pages(service, existing_pages[1:])
+                updated_page["_a_ka_action"] = "updated_hit_count"
+                return updated_page
+
+            _archive_duplicate_summary_pages(service, existing_pages[1:])
+            existing_page["_a_ka_action"] = "existing"
+            return existing_page
+
+    created_page = service.create_summary_database_item(
         data_source_id=connection.summary_data_source_id,
         title=title,
         summary=summary,
         category=category,
         source_url=source_url,
+        hit_count=hit_count,
     )
+    created_page["_a_ka_action"] = "created"
+    return created_page
+
+
+def _archive_duplicate_summary_pages(
+    service: NotionService,
+    duplicate_pages: list[dict[str, Any]],
+) -> None:
+    for page in duplicate_pages:
+        page_id = page.get("id")
+        if not page_id:
+            continue
+        try:
+            service.archive_page(page_id)
+        except NotionServiceError as exc:
+            logger.warning(
+                "Failed to archive duplicate Notion summary row. page_id=%s status=%s: %s",
+                page_id,
+                exc.status_code,
+                exc,
+            )
 
 
 def _clear_summary_database_ids(

--- a/app/services/notion_service.py
+++ b/app/services/notion_service.py
@@ -22,6 +22,9 @@ class NotionService:
     base_url = "https://api.notion.com/v1"
     rich_text_limit = 2000
     oauth_state_type = "notion_oauth_state"
+    summary_hit_count_property = "조회수"
+    summary_hit_count_view_name = "조회수 높은 순"
+    summary_source_url_property = "원본 URL"
 
     def __init__(self, api_key: str | None = None, notion_version: str | None = None):
         self.api_key = api_key or ""
@@ -106,6 +109,30 @@ class NotionService:
         if not normalized_page_id:
             raise NotionServiceError("page_id is required.", status_code=400)
         return self._request("GET", f"/pages/{normalized_page_id}")
+
+    def update_page_properties(
+        self,
+        page_id: str,
+        properties: dict[str, Any],
+    ) -> dict[str, Any]:
+        normalized_page_id = self._normalize_page_id(page_id)
+        if not normalized_page_id:
+            raise NotionServiceError("page_id is required.", status_code=400)
+        return self._request(
+            "PATCH",
+            f"/pages/{normalized_page_id}",
+            json={"properties": properties},
+        )
+
+    def archive_page(self, page_id: str) -> dict[str, Any]:
+        normalized_page_id = self._normalize_page_id(page_id)
+        if not normalized_page_id:
+            raise NotionServiceError("page_id is required.", status_code=400)
+        return self._request(
+            "PATCH",
+            f"/pages/{normalized_page_id}",
+            json={"archived": True},
+        )
 
     def build_oauth_authorization_url(self, state: str) -> str:
         if not settings.NOTION_OAUTH_CLIENT_ID:
@@ -273,6 +300,162 @@ class NotionService:
             raise NotionServiceError("database_id is required.", status_code=400)
         return self._request("GET", f"/databases/{normalized_database_id}")
 
+    def retrieve_data_source(
+        self,
+        data_source_id: str,
+    ) -> dict[str, Any]:
+        normalized_data_source_id = self._normalize_page_id(data_source_id)
+        if not normalized_data_source_id:
+            raise NotionServiceError("data_source_id is required.", status_code=400)
+        return self._request("GET", f"/data_sources/{normalized_data_source_id}")
+
+    def update_data_source(
+        self,
+        data_source_id: str,
+        properties: dict[str, Any],
+    ) -> dict[str, Any]:
+        normalized_data_source_id = self._normalize_page_id(data_source_id)
+        if not normalized_data_source_id:
+            raise NotionServiceError("data_source_id is required.", status_code=400)
+        return self._request(
+            "PATCH",
+            f"/data_sources/{normalized_data_source_id}",
+            json={"properties": properties},
+        )
+
+    def query_data_source(
+        self,
+        data_source_id: str,
+        *,
+        filter: dict[str, Any] | None = None,
+        sorts: list[dict[str, Any]] | None = None,
+        page_size: int = 10,
+    ) -> dict[str, Any]:
+        normalized_data_source_id = self._normalize_page_id(data_source_id)
+        if not normalized_data_source_id:
+            raise NotionServiceError("data_source_id is required.", status_code=400)
+
+        body: dict[str, Any] = {"page_size": page_size}
+        if filter:
+            body["filter"] = filter
+        if sorts:
+            body["sorts"] = sorts
+
+        return self._request(
+            "POST",
+            f"/data_sources/{normalized_data_source_id}/query",
+            json=body,
+        )
+
+    def list_views(self, database_id: str) -> dict[str, Any]:
+        normalized_database_id = self._normalize_page_id(database_id)
+        if not normalized_database_id:
+            raise NotionServiceError("database_id is required.", status_code=400)
+        query = urlencode({"database_id": normalized_database_id})
+        return self._request("GET", f"/views?{query}")
+
+    def retrieve_view(self, view_id: str) -> dict[str, Any]:
+        normalized_view_id = self._normalize_page_id(view_id)
+        if not normalized_view_id:
+            raise NotionServiceError("view_id is required.", status_code=400)
+        return self._request("GET", f"/views/{normalized_view_id}")
+
+    def create_view(
+        self,
+        database_id: str,
+        data_source_id: str,
+        name: str,
+        sorts: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        normalized_database_id = self._normalize_page_id(database_id)
+        normalized_data_source_id = self._normalize_page_id(data_source_id)
+        if not normalized_database_id:
+            raise NotionServiceError("database_id is required.", status_code=400)
+        if not normalized_data_source_id:
+            raise NotionServiceError("data_source_id is required.", status_code=400)
+
+        body = {
+            "database_id": normalized_database_id,
+            "data_source_id": normalized_data_source_id,
+            "name": name,
+            "type": "table",
+            "sorts": sorts,
+            "position": {"type": "start"},
+        }
+        return self._request("POST", "/views", json=body)
+
+    def update_view(
+        self,
+        view_id: str,
+        sorts: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        normalized_view_id = self._normalize_page_id(view_id)
+        if not normalized_view_id:
+            raise NotionServiceError("view_id is required.", status_code=400)
+        return self._request(
+            "PATCH",
+            f"/views/{normalized_view_id}",
+            json={"sorts": sorts},
+        )
+
+    def ensure_summary_database_schema(self, data_source_id: str) -> dict[str, Any]:
+        data_source = self.retrieve_data_source(data_source_id)
+        properties = data_source.get("properties") or {}
+        hit_count_property = properties.get(self.summary_hit_count_property)
+        if (
+            isinstance(hit_count_property, dict)
+            and hit_count_property.get("type") == "number"
+        ):
+            return data_source
+
+        return self.update_data_source(
+            data_source_id,
+            {
+                self.summary_hit_count_property: {
+                    "number": {"format": "number"}
+                }
+            },
+        )
+
+    def ensure_hit_count_sorted_view(
+        self,
+        database_id: str,
+        data_source_id: str,
+    ) -> dict[str, Any]:
+        sorts = self._hit_count_descending_sorts()
+        views = self.list_views(database_id).get("results", [])
+        normalized_data_source_id = self._normalize_page_id(data_source_id)
+        sort_property_identifiers: set[str] | None = None
+
+        for view_ref in views:
+            if view_ref.get("name") != self.summary_hit_count_view_name:
+                continue
+
+            view = view_ref
+            if "sorts" not in view or "data_source_id" not in view:
+                view = self.retrieve_view(view_ref["id"])
+
+            view_data_source_id = self._normalize_page_id(view.get("data_source_id"))
+            if view_data_source_id and view_data_source_id != normalized_data_source_id:
+                continue
+            if sort_property_identifiers is None:
+                sort_property_identifiers = self._hit_count_sort_property_identifiers(
+                    data_source_id
+                )
+            if self._is_hit_count_descending_sorts(
+                view.get("sorts"),
+                sort_property_identifiers,
+            ):
+                return view
+            return self.update_view(view["id"], sorts)
+
+        return self.create_view(
+            database_id=database_id,
+            data_source_id=data_source_id,
+            name=self.summary_hit_count_view_name,
+            sorts=sorts,
+        )
+
     def create_summary_database_item(
         self,
         data_source_id: str,
@@ -281,6 +464,7 @@ class NotionService:
         category: str | None = None,
         source_url: str | None = None,
         saved_at: datetime | None = None,
+        hit_count: int | None = 1,
     ) -> dict[str, Any]:
         normalized_data_source_id = self._normalize_page_id(data_source_id)
         if not normalized_data_source_id:
@@ -301,7 +485,12 @@ class NotionService:
         if category:
             properties["카테고리"] = {"select": {"name": category[:100]}}
         if source_url:
-            properties["원본 URL"] = {"url": source_url}
+            properties[self.summary_source_url_property] = {"url": source_url}
+        if hit_count is not None:
+            properties[self.summary_hit_count_property] = {
+                "number": max(int(hit_count), 0)
+            }
+
         body: dict[str, Any] = {
             "parent": {
                 "type": "data_source_id",
@@ -311,6 +500,56 @@ class NotionService:
             "children": self._summary_blocks(summary, source_url),
         }
         return self._request("POST", "/pages", json=body)
+
+    def find_summary_database_item_by_source_url(
+        self,
+        data_source_id: str,
+        source_url: str,
+    ) -> dict[str, Any] | None:
+        results = self.find_summary_database_items_by_source_url(
+            data_source_id,
+            source_url,
+            page_size=1,
+        )
+        return results[0] if results else None
+
+    def find_summary_database_items_by_source_url(
+        self,
+        data_source_id: str,
+        source_url: str,
+        *,
+        page_size: int = 100,
+    ) -> list[dict[str, Any]]:
+        response = self.query_data_source(
+            data_source_id,
+            filter={
+                "property": self.summary_source_url_property,
+                "url": {"equals": source_url},
+            },
+            sorts=[
+                {
+                    "property": self.summary_hit_count_property,
+                    "direction": "descending",
+                }
+            ],
+            page_size=page_size,
+        )
+        results = response.get("results") or []
+        return results if isinstance(results, list) else []
+
+    def update_summary_database_item_hit_count(
+        self,
+        page_id: str,
+        hit_count: int,
+    ) -> dict[str, Any]:
+        return self.update_page_properties(
+            page_id,
+            {
+                self.summary_hit_count_property: {
+                    "number": max(int(hit_count), 0)
+                }
+            },
+        )
 
     @staticmethod
     def extract_data_source_id(database_payload: dict[str, Any]) -> str:
@@ -342,7 +581,50 @@ class NotionService:
             "원본 URL": {"url": {}},
             "요약": {"rich_text": {}},
             "저장일": {"date": {}},
+            NotionService.summary_hit_count_property: {
+                "number": {"format": "number"}
+            },
         }
+
+    @staticmethod
+    def _hit_count_descending_sorts() -> list[dict[str, str]]:
+        return [
+            {
+                "property": NotionService.summary_hit_count_property,
+                "direction": "descending",
+            }
+        ]
+
+    def _hit_count_sort_property_identifiers(self, data_source_id: str) -> set[str]:
+        identifiers = {self.summary_hit_count_property}
+        try:
+            data_source = self.retrieve_data_source(data_source_id)
+        except NotionServiceError:
+            return identifiers
+
+        hit_count_property = (data_source.get("properties") or {}).get(
+            self.summary_hit_count_property
+        )
+        if isinstance(hit_count_property, dict):
+            property_id = hit_count_property.get("id")
+            if property_id:
+                identifiers.add(property_id)
+        return identifiers
+
+    @staticmethod
+    def _is_hit_count_descending_sorts(
+        sorts: Any,
+        property_identifiers: set[str],
+    ) -> bool:
+        if not isinstance(sorts, list) or len(sorts) != 1:
+            return False
+
+        sort = sorts[0]
+        return (
+            isinstance(sort, dict)
+            and sort.get("direction") == "descending"
+            and sort.get("property") in property_identifiers
+        )
 
     def _summary_blocks(
         self,

--- a/app/services/youtube_service.py
+++ b/app/services/youtube_service.py
@@ -1,3 +1,5 @@
+import logging
+
 from youtube_transcript_api import YouTubeTranscriptApi
 from urllib.parse import urlparse, parse_qs
 import os
@@ -11,8 +13,12 @@ from yt_dlp import YoutubeDL
 from ..core.config import settings
 
 
+logger = logging.getLogger(__name__)
+
+
 class YouTubeService:
     BASE_URL = "https://www.googleapis.com/youtube/v3/videos"
+    OEMBED_URL = "https://www.youtube.com/oembed"
 
     # whisper_model (tiny < base < small < medium < large)
     def __init__(self, whisper_model_name: str = "base"):
@@ -44,6 +50,26 @@ class YouTubeService:
     
     ###### youtube metadata 추출 ######
     def get_metadata(self, video_id: str) -> dict:
+        try:
+            return self._fetch_metadata_via_data_api(video_id)
+        except Exception as exc:
+            logger.warning(
+                "YouTube Data API failed for video_id=%s (%s); "
+                "falling back to oEmbed.",
+                video_id,
+                exc,
+            )
+
+        oembed_metadata = self._fetch_metadata_via_oembed(video_id)
+        if oembed_metadata is not None:
+            return oembed_metadata
+
+        raise ValueError(f"YouTube metadata not found for video_id={video_id}")
+
+    def _fetch_metadata_via_data_api(self, video_id: str) -> dict:
+        if not self.api_key:
+            raise RuntimeError("YOUTUBE_API_KEY is not configured")
+
         params = {
             "part": "snippet,contentDetails",
             "id": video_id,
@@ -59,7 +85,6 @@ class YouTubeService:
             raise ValueError("YouTube metadata not found")
 
         item = items[0]
-
         snippet = item["snippet"]
         content_details = item["contentDetails"]
 
@@ -71,6 +96,38 @@ class YouTubeService:
             "video_title": snippet["title"],
             "channel_name": snippet["channelTitle"],
             "duration": duration_ms,
+        }
+
+    def _fetch_metadata_via_oembed(self, video_id: str) -> dict | None:
+        """Fallback that uses the public, key-less oEmbed endpoint.
+
+        Only title and channel name are available from oEmbed; duration is set
+        to 0 and should be filled in later if needed.
+        """
+        try:
+            resp = requests.get(
+                self.OEMBED_URL,
+                params={
+                    "url": f"https://www.youtube.com/watch?v={video_id}",
+                    "format": "json",
+                },
+                timeout=10,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except Exception as exc:
+            logger.warning(
+                "YouTube oEmbed fallback failed for video_id=%s: %s",
+                video_id,
+                exc,
+            )
+            return None
+
+        return {
+            "video_id": video_id,
+            "video_title": payload.get("title") or "Unknown",
+            "channel_name": payload.get("author_name") or "Unknown",
+            "duration": 0,
         }
 
     def get_transcript(self, video_id: str, language="ko"):

--- a/app/tasks/knowledge_tasks.py
+++ b/app/tasks/knowledge_tasks.py
@@ -140,12 +140,15 @@ def run_core_pipeline_task(
                     or f"YouTube summary {video_id}",
                     full_summary=duplicate_result.get("summary") or "Summary is empty.",
                     category=duplicate_result.get("category"),
+                    hit_count=duplicate_result.get("hit_count"),
                 )
-                response["status"] = (
-                    "duplicate_saved_to_notion"
-                    if notion_page
-                    else "duplicate_no_notion"
-                )
+                response["status"] = "duplicate_no_notion"
+                if notion_page:
+                    response["status"] = (
+                        "duplicate_hit_count_updated_in_notion"
+                        if notion_page.get("action") == "updated_hit_count"
+                        else "duplicate_saved_to_notion"
+                    )
                 response["notion_page"] = notion_page
 
             return response

--- a/manual_notion_connect.py
+++ b/manual_notion_connect.py
@@ -1,0 +1,234 @@
+"""Manual helper for the first Notion OAuth connection.
+
+Fill DEFAULT_USER below, then run while the FastAPI server is running:
+
+    python manual_notion_connect.py
+
+The script logs in with the local test user, creates the Notion OAuth URL, opens
+it in your browser, and polls /api/v1/notion/me until the connection is ready.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import time
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+# Fill this in if you want to run this file without command-line arguments.
+DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+DEFAULT_USER = "suwang_test_1"
+DEFAULT_OPEN_BROWSER = True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Connect a local user to Notion.")
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="FastAPI base URL.",
+    )
+    parser.add_argument(
+        "--user",
+        default=DEFAULT_USER,
+        help="Local login user_name to connect with Notion.",
+    )
+    parser.add_argument(
+        "--no-open",
+        action="store_true",
+        help="Print the OAuth URL without opening a browser.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=180,
+        help="Seconds to wait for the OAuth callback to complete.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=3,
+        help="Seconds between /notion/me polling attempts.",
+    )
+
+    args = parser.parse_args()
+    if not args.user:
+        parser.error("Set DEFAULT_USER in the file or pass --user.")
+    return args
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    json: dict[str, Any] | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    data = None
+    if json is not None:
+        data = json_dumps(json).encode("utf-8")
+
+    request_headers = dict(headers or {})
+    if data is not None:
+        request_headers["Content-Type"] = "application/json"
+
+    scheme, host, port, path = split_url(url)
+    connection_cls = (
+        http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    )
+    connection = connection_cls(host, port=port, timeout=timeout)
+    try:
+        connection.request(method, path, body=data, headers=request_headers)
+        response = connection.getresponse()
+        raw = response.read()
+        if 200 <= response.status < 300:
+            return json_loads(raw)
+
+        detail = json_loads(raw)
+        raise RuntimeError(f"{method} {url} failed: {response.status} {detail}")
+    finally:
+        connection.close()
+
+
+def split_url(url: str) -> tuple[str, str, int | None, str]:
+    if "://" not in url:
+        raise ValueError(f"Invalid URL: {url}")
+
+    scheme, rest = url.split("://", 1)
+    host_port, _, path = rest.partition("/")
+    host, port = split_host_port(host_port, scheme)
+    return scheme, host, port, "/" + path
+
+
+def split_host_port(host_port: str, scheme: str) -> tuple[str, int | None]:
+    if ":" not in host_port:
+        return host_port, 443 if scheme == "https" else 80
+
+    host, port_text = host_port.rsplit(":", 1)
+    return host, int(port_text)
+
+
+def json_dumps(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def json_loads(raw: bytes) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except ValueError:
+        return {"raw": raw.decode("utf-8", errors="replace")}
+    return value if isinstance(value, dict) else {"value": value}
+
+
+def login(base_url: str, user_name: str) -> dict[str, str]:
+    body = request_json(
+        "POST",
+        f"{base_url}/api/v1/auth/login/local",
+        json={"user_name": user_name},
+    )
+    user = body["user"]
+    print(f"[ok] logged in user_id={user['id']} user_name={user.get('user_name')}")
+    return {"Authorization": f"Bearer {body['access_token']}"}
+
+
+def create_oauth_url(base_url: str, headers: dict[str, str]) -> str:
+    body = request_json(
+        "GET",
+        f"{base_url}/api/v1/notion/oauth/start",
+        headers=headers,
+    )
+    authorization_url = body["authorization_url"]
+    validate_oauth_redirect_uri(authorization_url)
+    print("\nNotion OAuth URL:")
+    print(authorization_url)
+    return authorization_url
+
+
+def validate_oauth_redirect_uri(authorization_url: str) -> None:
+    parsed = urlparse(authorization_url)
+    redirect_uri = parse_qs(parsed.query).get("redirect_uri", [""])[0]
+    if redirect_uri.startswith("https://"):
+        return
+
+    raise RuntimeError(
+        "Notion OAuth redirect_uri must be HTTPS for this integration.\n"
+        f"Current redirect_uri: {redirect_uri or '(missing)'}\n"
+        "Create an HTTPS tunnel, then set NOTION_OAUTH_REDIRECT_URI to:\n"
+        "  https://YOUR-TUNNEL/api/v1/notion/oauth/callback\n"
+        "Register the exact same URL in the Notion developer dashboard and "
+        "restart FastAPI."
+    )
+
+
+def get_notion_status(base_url: str, headers: dict[str, str]) -> dict[str, Any]:
+    return request_json("GET", f"{base_url}/api/v1/notion/me", headers=headers)
+
+
+def wait_until_ready(
+    base_url: str,
+    headers: dict[str, str],
+    *,
+    timeout: int,
+    poll_interval: int,
+) -> dict[str, Any]:
+    print("\n[wait] approve the Notion OAuth request in your browser")
+    deadline = time.time() + timeout
+    last_status: dict[str, Any] | None = None
+
+    while time.time() < deadline:
+        last_status = get_notion_status(base_url, headers)
+        if last_status.get("connected") and last_status.get("ready"):
+            print("[ok] Notion connection is ready")
+            return last_status
+
+        print(
+            "[wait] "
+            f"connected={last_status.get('connected')} "
+            f"ready={last_status.get('ready')} "
+            f"parent_page_id={last_status.get('parent_page_id')}"
+        )
+        time.sleep(poll_interval)
+
+    raise TimeoutError(f"Timed out waiting for Notion connection: {last_status}")
+
+
+def run() -> None:
+    args = parse_args()
+    base_url = args.base_url.rstrip("/")
+    headers = login(base_url, args.user)
+    authorization_url = create_oauth_url(base_url, headers)
+
+    if DEFAULT_OPEN_BROWSER and not args.no_open:
+        import webbrowser
+
+        opened = webbrowser.open(authorization_url)
+        if opened:
+            print("[ok] browser opened")
+        else:
+            print("[warn] could not open browser automatically; paste the URL manually")
+    else:
+        print("\nOpen the URL above in your browser.")
+
+    status = wait_until_ready(
+        base_url,
+        headers,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+    )
+    print("\nConnection:")
+    print(f"  workspace_id: {status.get('workspace_id')}")
+    print(f"  workspace_name: {status.get('workspace_name')}")
+    print(f"  parent_page_id: {status.get('parent_page_id')}")
+    print(f"  summary_database_id: {status.get('summary_database_id')}")
+    print(f"  summary_data_source_id: {status.get('summary_data_source_id')}")
+    print("\nPASS: Notion connection completed.")
+
+
+if __name__ == "__main__":
+    run()

--- a/manual_notion_hit_count_e2e.py
+++ b/manual_notion_hit_count_e2e.py
@@ -1,0 +1,544 @@
+"""Manual E2E test for Notion hit_count saving and sorted view.
+
+Set DEFAULT_USER and DEFAULT_URL below, then run from the repository root while
+the API server, Celery worker, Redis, and DB are running:
+
+    python manual_notion_hit_count_e2e.py
+
+You can still override them from the command line:
+
+    python manual_notion_hit_count_e2e.py --user external_user_test_3 --url https://www.youtube.com/watch?v=VIDEO_ID
+
+The script checks:
+1. Local login works.
+2. The user has a ready Notion connection.
+3. The first summarize request reaches COMPLETED, or the video already exists.
+4. On the first run for a video, hit_count is 1.
+   On every subsequent run, one duplicate request is sent and hit_count is
+   asserted to be +1. Pass --no-check-duplicate to skip the duplicate request.
+5. The Notion data source has the hit_count property and sorted view.
+6. A Notion row for the source URL appears with the expected hit_count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import requests
+from sqlalchemy import create_engine, text
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.core.config import settings  # noqa: E402
+from app.services.notion_service import NotionService  # noqa: E402
+
+SOURCE_URL_PROPERTY = "\uc6d0\ubcf8 URL"
+YOUTUBE_VIDEO_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+# Fill these in if you want to run this file without command-line arguments.
+DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+DEFAULT_USER = "suwang_test_1"
+DEFAULT_URL = "https://www.youtube.com/watch?v=uZuVgr-z3bE"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the Notion hit_count duplicate-save E2E flow."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="FastAPI base URL.",
+    )
+    parser.add_argument(
+        "--user",
+        default=DEFAULT_USER,
+        help="Local login user_name that already has a ready Notion connection.",
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help="YouTube URL to test.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=420,
+        help="Seconds to wait for the first pipeline completion.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=5,
+        help="Seconds between DB polling attempts.",
+    )
+    parser.add_argument(
+        "--notion-timeout",
+        type=int,
+        default=90,
+        help="Seconds to wait for Notion row consistency.",
+    )
+    parser.add_argument(
+        "--skip-notion-api",
+        action="store_true",
+        help="Skip direct Notion API schema, view, and row verification.",
+    )
+    duplicate_group = parser.add_mutually_exclusive_group()
+    duplicate_group.add_argument(
+        "--check-duplicate",
+        dest="check_duplicate",
+        action="store_true",
+        default=True,
+        help=(
+            "Send one duplicate summarize request and assert hit_count increments "
+            "by 1 (default on subsequent runs)."
+        ),
+    )
+    duplicate_group.add_argument(
+        "--no-check-duplicate",
+        dest="check_duplicate",
+        action="store_false",
+        help="Skip the duplicate summarize request and only verify the current state.",
+    )
+    args = parser.parse_args()
+    if not args.user:
+        parser.error("Set DEFAULT_USER in the file or pass --user.")
+    if not args.url:
+        parser.error("Set DEFAULT_URL in the file or pass --url.")
+    return args
+
+
+def sync_database_url() -> str:
+    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+def extract_youtube_video_id(youtube_url: str) -> str:
+    value = youtube_url.strip()
+    if YOUTUBE_VIDEO_ID_PATTERN.fullmatch(value):
+        return value
+
+    parsed = urlparse(value)
+    query_video_id = parse_qs(parsed.query).get("v", [""])[0]
+    if YOUTUBE_VIDEO_ID_PATTERN.fullmatch(query_video_id):
+        return query_video_id
+
+    for path_part in reversed([part for part in parsed.path.split("/") if part]):
+        if YOUTUBE_VIDEO_ID_PATTERN.fullmatch(path_part):
+            return path_part
+
+    raise RuntimeError(f"Could not extract a YouTube video id from: {youtube_url}")
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    json: dict[str, Any] | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    response = requests.request(
+        method,
+        url,
+        headers=headers,
+        json=json,
+        timeout=timeout,
+    )
+    if response.ok:
+        return response.json()
+
+    try:
+        detail = response.json()
+    except ValueError:
+        detail = response.text
+    raise RuntimeError(f"{method} {url} failed: {response.status_code} {detail}")
+
+
+def login(base_url: str, user_name: str) -> tuple[dict[str, str], int]:
+    body = request_json(
+        "POST",
+        f"{base_url}/api/v1/auth/login/local",
+        json={"user_name": user_name},
+    )
+    user_id = int(body["user"]["id"])
+    token = body["access_token"]
+    print(f"[ok] logged in user_id={user_id}")
+    return {"Authorization": f"Bearer {token}"}, user_id
+
+
+def require_ready_notion(base_url: str, headers: dict[str, str]) -> dict[str, Any]:
+    notion = request_json("GET", f"{base_url}/api/v1/notion/me", headers=headers)
+    if not notion.get("connected") or not notion.get("ready"):
+        raise RuntimeError(
+            "Notion is not ready for this user. Connect Notion and select a parent "
+            "page first."
+        )
+    print(
+        "[ok] notion ready "
+        f"database={notion.get('summary_database_id')} "
+        f"data_source={notion.get('summary_data_source_id')}"
+    )
+    return notion
+
+
+def summarize(
+    base_url: str,
+    headers: dict[str, str],
+    youtube_url: str,
+) -> dict[str, Any]:
+    response = request_json(
+        "POST",
+        f"{base_url}/api/v1/youtube/summarize",
+        headers=headers,
+        json={"url": youtube_url},
+        timeout=150,
+    )
+    print(
+        "[ok] summarize "
+        f"status={response.get('status')} "
+        f"video_id={response.get('video_id')} "
+        f"hit_count={response.get('hit_count')} "
+        f"duplicate={response.get('duplicate')} "
+        f"task_id={response.get('task_id')}"
+    )
+    return response
+
+
+def latest_knowledge(engine, user_id: int, video_id: str) -> dict[str, Any] | None:
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT
+                    k.id::text AS knowledge_id,
+                    k.status::text AS status,
+                    k.hit_count AS hit_count,
+                    k.title AS title,
+                    k.updated_at AS updated_at
+                FROM knowledge k
+                JOIN youtube_metadata ym ON ym.knowledge_id = k.id
+                WHERE k.user_id = :user_id AND ym.video_id = :video_id
+                ORDER BY k.created_at DESC
+                LIMIT 1
+                """
+            ),
+            {"user_id": user_id, "video_id": video_id},
+        ).mappings().fetchone()
+
+    return dict(row) if row else None
+
+
+def wait_for_completed(
+    engine,
+    user_id: int,
+    video_id: str,
+    *,
+    timeout: int,
+    poll_interval: int,
+) -> dict[str, Any]:
+    print(f"[wait] polling DB until video_id={video_id} is COMPLETED")
+    deadline = time.time() + timeout
+    last_status = None
+
+    while time.time() < deadline:
+        row = latest_knowledge(engine, user_id, video_id)
+        if row:
+            last_status = row["status"]
+            if last_status == "COMPLETED":
+                print(
+                    "[ok] pipeline completed "
+                    f"knowledge_id={row['knowledge_id']} hit_count={row['hit_count']}"
+                )
+                return row
+            if last_status == "FAILED":
+                raise RuntimeError(f"pipeline failed for video_id={video_id}")
+
+        print(f"[wait] status={last_status or 'missing'}")
+        time.sleep(poll_interval)
+
+    raise TimeoutError(
+        f"Timed out after {timeout}s waiting for video_id={video_id}; "
+        f"last_status={last_status}"
+    )
+
+
+def notion_connection(engine, user_id: int) -> dict[str, Any]:
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT
+                    access_token,
+                    summary_database_id,
+                    summary_data_source_id
+                FROM notion_connection
+                WHERE user_id = :user_id
+                LIMIT 1
+                """
+            ),
+            {"user_id": user_id},
+        ).mappings().fetchone()
+
+    if not row:
+        raise RuntimeError(f"No notion_connection row for user_id={user_id}")
+    return dict(row)
+
+
+def notion_headers(access_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Notion-Version": settings.NOTION_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+def notion_request(
+    method: str,
+    path: str,
+    *,
+    access_token: str,
+    json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return request_json(
+        method,
+        f"{NotionService.base_url}{path}",
+        headers=notion_headers(access_token),
+        json=json,
+    )
+
+
+def verify_notion_schema_and_view(connection: dict[str, Any]) -> None:
+    access_token = connection["access_token"]
+    database_id = connection["summary_database_id"]
+    data_source_id = connection["summary_data_source_id"]
+    if not database_id or not data_source_id:
+        raise RuntimeError("Notion summary database/data source ids are missing.")
+
+    data_source = notion_request(
+        "GET",
+        f"/data_sources/{data_source_id}",
+        access_token=access_token,
+    )
+    hit_count_property = (data_source.get("properties") or {}).get(
+        NotionService.summary_hit_count_property
+    )
+    if not hit_count_property or hit_count_property.get("type") != "number":
+        raise AssertionError("Notion data source is missing the hit_count number field.")
+    print("[ok] notion data source has hit_count number property")
+    hit_count_sort_properties = {NotionService.summary_hit_count_property}
+    hit_count_property_id = hit_count_property.get("id")
+    if hit_count_property_id:
+        hit_count_sort_properties.add(hit_count_property_id)
+
+    views = notion_request(
+        "GET",
+        f"/views?database_id={database_id}",
+        access_token=access_token,
+    ).get("results", [])
+
+    for view_ref in views:
+        view = notion_request("GET", f"/views/{view_ref['id']}", access_token=access_token)
+        if view.get("name") != NotionService.summary_hit_count_view_name:
+            continue
+        if not is_hit_count_descending_sort(
+            view.get("sorts"),
+            hit_count_sort_properties,
+        ):
+            raise AssertionError(f"Hit-count view has unexpected sorts: {view.get('sorts')}")
+        print("[ok] notion hit_count sorted view exists")
+        return
+
+    raise AssertionError("Notion hit_count sorted view was not found.")
+
+
+def is_hit_count_descending_sort(
+    sorts: Any,
+    property_identifiers: set[str],
+) -> bool:
+    if not isinstance(sorts, list) or len(sorts) != 1:
+        return False
+
+    sort = sorts[0]
+    return (
+        isinstance(sort, dict)
+        and sort.get("direction") == "descending"
+        and sort.get("property") in property_identifiers
+    )
+
+
+def query_notion_rows(
+    connection: dict[str, Any],
+    *,
+    page_size: int = 100,
+) -> list[dict[str, Any]]:
+    payload = {
+        "page_size": page_size,
+        "sorts": [
+            {
+                "property": NotionService.summary_hit_count_property,
+                "direction": "descending",
+            }
+        ],
+    }
+    response = notion_request(
+        "POST",
+        f"/data_sources/{connection['summary_data_source_id']}/query",
+        access_token=connection["access_token"],
+        json=payload,
+    )
+    return response.get("results", [])
+
+
+def page_property(page: dict[str, Any], property_name: str) -> dict[str, Any]:
+    value = (page.get("properties") or {}).get(property_name)
+    return value if isinstance(value, dict) else {}
+
+
+def verify_notion_row(
+    connection: dict[str, Any],
+    *,
+    source_url: str,
+    expected_hit_count: int,
+    timeout: int,
+) -> None:
+    print("[wait] querying Notion rows for expected hit_count")
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        rows = query_notion_rows(connection)
+        hit_counts = [
+            page_property(row, NotionService.summary_hit_count_property).get("number")
+            for row in rows
+        ]
+        if hit_counts != sorted(hit_counts, reverse=True):
+            raise AssertionError(f"Notion query was not sorted descending: {hit_counts}")
+
+        matching_rows = [
+            row
+            for row in rows
+            if page_property(row, SOURCE_URL_PROPERTY).get("url") == source_url
+        ]
+        if len(matching_rows) > 1:
+            raise AssertionError(
+                f"Expected one Notion row for url={source_url}, "
+                f"found {len(matching_rows)}"
+            )
+
+        for row in matching_rows:
+            hit_count = page_property(row, NotionService.summary_hit_count_property).get(
+                "number"
+            )
+            if hit_count == expected_hit_count:
+                print(
+                    "[ok] notion row found "
+                    f"url={source_url} hit_count={expected_hit_count}"
+                )
+                return
+
+        print(f"[wait] latest notion hit_counts={hit_counts}")
+        time.sleep(3)
+
+    raise TimeoutError(
+        f"Timed out waiting for Notion row url={source_url} "
+        f"hit_count={expected_hit_count}"
+    )
+
+
+def run() -> None:
+    args = parse_args()
+    base_url = args.base_url.rstrip("/")
+    engine = create_engine(sync_database_url(), pool_pre_ping=True)
+
+    headers, user_id = login(base_url, args.user)
+    require_ready_notion(base_url, headers)
+
+    video_id = extract_youtube_video_id(args.url)
+    before_duplicate = latest_knowledge(engine, user_id, video_id)
+    record_just_created = before_duplicate is None
+
+    if before_duplicate is None:
+        first_response = summarize(base_url, headers, args.url)
+        if first_response["video_id"] != video_id:
+            raise AssertionError(
+                f"Expected video_id={video_id}, got {first_response['video_id']}"
+            )
+        if first_response.get("status") != "QUEUED":
+            raise AssertionError(
+                "Expected first request to queue a new pipeline, got "
+                f"{first_response}"
+            )
+        before_duplicate = wait_for_completed(
+            engine,
+            user_id,
+            video_id,
+            timeout=args.timeout,
+            poll_interval=args.poll_interval,
+        )
+    elif before_duplicate["status"] != "COMPLETED":
+        before_duplicate = wait_for_completed(
+            engine,
+            user_id,
+            video_id,
+            timeout=args.timeout,
+            poll_interval=args.poll_interval,
+        )
+
+    current_hit_count = int(before_duplicate["hit_count"] or 0)
+    expected_hit_count = current_hit_count
+    print(f"[ok] current hit_count={current_hit_count}")
+
+    # Increment only on subsequent runs. The very first run already produced
+    # hit_count=1 by creating the record, so don't double-bump it.
+    should_check_duplicate = args.check_duplicate and not record_just_created
+
+    if should_check_duplicate:
+        duplicate_response = summarize(base_url, headers, args.url)
+        if not duplicate_response.get("duplicate"):
+            raise AssertionError(f"Expected duplicate response, got {duplicate_response}")
+        if duplicate_response.get("status") != "duplicate_hit_count_updated_in_notion":
+            raise AssertionError(
+                "Expected duplicate_hit_count_updated_in_notion, got "
+                f"{duplicate_response.get('status')}"
+            )
+
+        expected_hit_count = current_hit_count + 1
+        actual_hit_count = int(duplicate_response["hit_count"])
+        if actual_hit_count != expected_hit_count:
+            raise AssertionError(
+                f"Expected hit_count={expected_hit_count}, got {actual_hit_count}"
+            )
+        print(f"[ok] duplicate response hit_count={actual_hit_count}")
+
+        after_duplicate = latest_knowledge(engine, user_id, video_id)
+        if not after_duplicate or int(after_duplicate["hit_count"]) != expected_hit_count:
+            raise AssertionError(f"DB hit_count was not updated: {after_duplicate}")
+        print("[ok] DB hit_count matches duplicate response")
+    elif record_just_created:
+        print("[ok] first run for this video; skipping duplicate request")
+    else:
+        print("[ok] duplicate check skipped; hit_count was not incremented")
+
+    require_ready_notion(base_url, headers)
+    if not args.skip_notion_api:
+        connection = notion_connection(engine, user_id)
+        verify_notion_schema_and_view(connection)
+        verify_notion_row(
+            connection,
+            source_url=f"https://www.youtube.com/watch?v={video_id}",
+            expected_hit_count=expected_hit_count,
+            timeout=args.notion_timeout,
+        )
+
+    print("\nPASS: Notion hit_count E2E flow succeeded.")
+
+
+if __name__ == "__main__":
+    run()

--- a/test_knowledge_tasks.py
+++ b/test_knowledge_tasks.py
@@ -1,0 +1,40 @@
+def test_duplicate_completed_passes_hit_count_to_notion(monkeypatch):
+    from app.tasks import knowledge_tasks as kt
+
+    async def fake_check_duplicate_hit_count(video_id, user_id):
+        assert video_id == "video123456"
+        assert user_id == 9
+        return {
+            "knowledge_id": "00000000-0000-0000-0000-000000000001",
+            "hit_count": 4,
+            "status": "COMPLETED",
+            "duplicate": True,
+            "counted": True,
+            "title": "Saved video",
+            "summary": "Saved summary",
+            "category": "Backend",
+        }
+
+    captured = {}
+
+    def fake_save_summary_to_user_notion(**kwargs):
+        captured.update(kwargs)
+        return {
+            "id": "row-id",
+            "url": "https://notion.so/row",
+            "action": "updated_hit_count",
+        }
+
+    monkeypatch.setattr(kt, "check_duplicate_hit_count", fake_check_duplicate_hit_count)
+    monkeypatch.setattr(kt, "save_summary_to_user_notion", fake_save_summary_to_user_notion)
+
+    response = kt.run_core_pipeline_task(
+        "https://www.youtube.com/watch?v=video123456",
+        "video123456",
+        9,
+    )
+
+    assert response["status"] == "duplicate_hit_count_updated_in_notion"
+    assert response["hit_count"] == 4
+    assert captured["hit_count"] == 4
+    assert captured["category"] == "Backend"

--- a/test_notion_connection_service.py
+++ b/test_notion_connection_service.py
@@ -1,0 +1,122 @@
+from app.services import notion_connection_service as service
+
+
+class DummyConnection:
+    user_id = 9
+    access_token = "secret"
+    summary_data_source_id = "data-source-id"
+
+
+def test_existing_notion_row_updates_only_hit_count(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        service,
+        "ensure_summary_database",
+        lambda db, connection, raise_errors: connection,
+    )
+
+    def fake_find(self, data_source_id, source_url):
+        calls.append(("find", data_source_id, source_url))
+        return [{"id": "page-id", "url": "https://notion.so/row"}]
+
+    def fake_update(self, page_id, hit_count):
+        calls.append(("update", page_id, hit_count))
+        return {"id": page_id, "url": "https://notion.so/row"}
+
+    def fake_create(self, **kwargs):
+        raise AssertionError("duplicate Notion rows must not be created")
+
+    monkeypatch.setattr(
+        service.NotionService,
+        "find_summary_database_items_by_source_url",
+        fake_find,
+    )
+    monkeypatch.setattr(
+        service.NotionService,
+        "update_summary_database_item_hit_count",
+        fake_update,
+    )
+    monkeypatch.setattr(
+        service.NotionService,
+        "create_summary_database_item",
+        fake_create,
+    )
+
+    page = service._create_summary_database_item_for_connection(
+        db=None,
+        connection=DummyConnection(),
+        title="Existing title",
+        summary="Existing summary",
+        source_url="https://www.youtube.com/watch?v=I2giEjUHe0M",
+        category="Backend",
+        hit_count=8,
+    )
+
+    assert page["_a_ka_action"] == "updated_hit_count"
+    assert calls == [
+        ("find", "data-source-id", "https://www.youtube.com/watch?v=I2giEjUHe0M"),
+        ("update", "page-id", 8),
+    ]
+
+
+def test_existing_duplicate_notion_rows_are_archived(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        service,
+        "ensure_summary_database",
+        lambda db, connection, raise_errors: connection,
+    )
+
+    def fake_find(self, data_source_id, source_url):
+        calls.append(("find", data_source_id, source_url))
+        return [
+            {"id": "keep-page-id", "url": "https://notion.so/keep"},
+            {"id": "archive-page-id", "url": "https://notion.so/archive"},
+        ]
+
+    def fake_update(self, page_id, hit_count):
+        calls.append(("update", page_id, hit_count))
+        return {"id": page_id, "url": "https://notion.so/keep"}
+
+    def fake_archive(self, page_id):
+        calls.append(("archive", page_id))
+        return {"id": page_id, "archived": True}
+
+    def fake_create(self, **kwargs):
+        raise AssertionError("duplicate Notion rows must not be created")
+
+    monkeypatch.setattr(
+        service.NotionService,
+        "find_summary_database_items_by_source_url",
+        fake_find,
+    )
+    monkeypatch.setattr(
+        service.NotionService,
+        "update_summary_database_item_hit_count",
+        fake_update,
+    )
+    monkeypatch.setattr(service.NotionService, "archive_page", fake_archive)
+    monkeypatch.setattr(
+        service.NotionService,
+        "create_summary_database_item",
+        fake_create,
+    )
+
+    page = service._create_summary_database_item_for_connection(
+        db=None,
+        connection=DummyConnection(),
+        title="Existing title",
+        summary="Existing summary",
+        source_url="https://www.youtube.com/watch?v=I2giEjUHe0M",
+        category="Backend",
+        hit_count=8,
+    )
+
+    assert page["_a_ka_action"] == "updated_hit_count"
+    assert calls == [
+        ("find", "data-source-id", "https://www.youtube.com/watch?v=I2giEjUHe0M"),
+        ("update", "keep-page-id", 8),
+        ("archive", "archive-page-id"),
+    ]

--- a/test_notion_service.py
+++ b/test_notion_service.py
@@ -105,6 +105,259 @@ def test_create_summary_page_normalizes_compact_page_id(monkeypatch):
     )
 
 
+def test_create_summary_database_includes_hit_count_property(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        captured.update({"method": method, "url": url, "json": kwargs["json"]})
+        return DummyResponse(
+            payload={
+                "id": "database-id",
+                "data_sources": [{"id": "data-source-id"}],
+            }
+        )
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    database = service.create_summary_database(
+        parent_page_id="3501b54ad663800f8e40f1d87631c4ec"
+    )
+
+    assert database["id"] == "database-id"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.notion.com/v1/databases"
+    properties = captured["json"]["initial_data_source"]["properties"]
+    assert properties[NotionService.summary_hit_count_property] == {
+        "number": {"format": "number"}
+    }
+
+
+def test_create_summary_database_item_sends_hit_count(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        captured.update({"method": method, "url": url, "json": kwargs["json"]})
+        return DummyResponse(payload={"id": "row-id", "url": "https://notion.so/row"})
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    page = service.create_summary_database_item(
+        data_source_id="3501b54ad663800f8e40f1d87631c4ec",
+        title="C language basics",
+        summary="Useful notes",
+        source_url="https://youtube.com/watch?v=I2giEjUHe0M",
+        hit_count=7,
+    )
+
+    assert page["id"] == "row-id"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.notion.com/v1/pages"
+    properties = captured["json"]["properties"]
+    assert properties[NotionService.summary_hit_count_property] == {"number": 7}
+
+
+def test_find_summary_database_item_by_source_url_queries_url_filter(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        captured.update({"method": method, "url": url, "json": kwargs["json"]})
+        return DummyResponse(payload={"results": [{"id": "page-id"}]})
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    page = service.find_summary_database_item_by_source_url(
+        data_source_id="3501b54ad663800f8e40f1d87631c4ec",
+        source_url="https://www.youtube.com/watch?v=I2giEjUHe0M",
+    )
+
+    assert page == {"id": "page-id"}
+    assert captured["method"] == "POST"
+    assert captured["url"] == (
+        "https://api.notion.com/v1/data_sources/"
+        "3501b54a-d663-800f-8e40-f1d87631c4ec/query"
+    )
+    assert captured["json"] == {
+        "page_size": 1,
+        "filter": {
+            "property": NotionService.summary_source_url_property,
+            "url": {"equals": "https://www.youtube.com/watch?v=I2giEjUHe0M"},
+        },
+        "sorts": [
+            {
+                "property": NotionService.summary_hit_count_property,
+                "direction": "descending",
+            }
+        ],
+    }
+
+
+def test_update_summary_database_item_hit_count_patches_only_hit_count(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        captured.update({"method": method, "url": url, "json": kwargs["json"]})
+        return DummyResponse(payload={"id": "page-id", "url": "https://notion.so/row"})
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    page = service.update_summary_database_item_hit_count(
+        "3501b54ad663800f8e40f1d87631c4ec",
+        8,
+    )
+
+    assert page["id"] == "page-id"
+    assert captured["method"] == "PATCH"
+    assert captured["url"] == (
+        "https://api.notion.com/v1/pages/"
+        "3501b54a-d663-800f-8e40-f1d87631c4ec"
+    )
+    assert captured["json"] == {
+        "properties": {
+            NotionService.summary_hit_count_property: {"number": 8}
+        }
+    }
+
+
+def test_archive_page_patches_archived_flag(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        captured.update({"method": method, "url": url, "json": kwargs["json"]})
+        return DummyResponse(payload={"id": "page-id", "archived": True})
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    page = service.archive_page("3501b54ad663800f8e40f1d87631c4ec")
+
+    assert page["archived"] is True
+    assert captured["method"] == "PATCH"
+    assert captured["url"] == (
+        "https://api.notion.com/v1/pages/"
+        "3501b54a-d663-800f-8e40-f1d87631c4ec"
+    )
+    assert captured["json"] == {"archived": True}
+
+
+def test_ensure_summary_database_schema_adds_hit_count(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        calls.append({"method": method, "url": url, "json": kwargs.get("json")})
+        if method == "GET":
+            return DummyResponse(payload={"properties": {"제목": {"type": "title"}}})
+        return DummyResponse(payload={"properties": {}})
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    service.ensure_summary_database_schema("3501b54ad663800f8e40f1d87631c4ec")
+
+    assert calls[0]["method"] == "GET"
+    assert calls[1]["method"] == "PATCH"
+    assert calls[1]["url"] == (
+        "https://api.notion.com/v1/data_sources/"
+        "3501b54a-d663-800f-8e40-f1d87631c4ec"
+    )
+    assert calls[1]["json"] == {
+        "properties": {
+            NotionService.summary_hit_count_property: {
+                "number": {"format": "number"}
+            }
+        }
+    }
+
+
+def test_ensure_hit_count_sorted_view_creates_first_table_view(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        calls.append({"method": method, "url": url, "json": kwargs.get("json")})
+        if method == "GET":
+            return DummyResponse(payload={"results": []})
+        return DummyResponse(payload={"id": "view-id", "object": "view"})
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    service.ensure_hit_count_sorted_view(
+        database_id="database-id",
+        data_source_id="data-source-id",
+    )
+
+    assert calls[0]["method"] == "GET"
+    assert calls[0]["url"] == (
+        "https://api.notion.com/v1/views?database_id=database-id"
+    )
+    assert calls[1]["method"] == "POST"
+    assert calls[1]["url"] == "https://api.notion.com/v1/views"
+    assert calls[1]["json"] == {
+        "database_id": "database-id",
+        "data_source_id": "data-source-id",
+        "name": NotionService.summary_hit_count_view_name,
+        "type": "table",
+        "sorts": [
+            {
+                "property": NotionService.summary_hit_count_property,
+                "direction": "descending",
+            }
+        ],
+        "position": {"type": "start"},
+    }
+
+
+def test_ensure_hit_count_sorted_view_accepts_property_id(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, headers, timeout, **kwargs):
+        calls.append({"method": method, "url": url, "json": kwargs.get("json")})
+        if url.endswith("/views?database_id=database-id"):
+            return DummyResponse(
+                payload={
+                    "results": [
+                        {
+                            "id": "view-id",
+                            "name": NotionService.summary_hit_count_view_name,
+                            "data_source_id": "data-source-id",
+                            "sorts": [
+                                {
+                                    "property": "YGki",
+                                    "direction": "descending",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+        if url.endswith("/data_sources/data-source-id"):
+            return DummyResponse(
+                payload={
+                    "properties": {
+                        NotionService.summary_hit_count_property: {
+                            "id": "YGki",
+                            "type": "number",
+                        }
+                    }
+                }
+            )
+        raise AssertionError(f"Unexpected request: {method} {url}")
+
+    monkeypatch.setattr("app.services.notion_service.requests.request", fake_request)
+
+    service = NotionService(api_key="secret", notion_version="2026-03-11")
+    view = service.ensure_hit_count_sorted_view(
+        database_id="database-id",
+        data_source_id="data-source-id",
+    )
+
+    assert view["id"] == "view-id"
+    assert [call["method"] for call in calls] == ["GET", "GET"]
+
+
 def test_retrieve_page_normalizes_page_id(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
**변경 사항**
- Notion: 요약 DB에 조회수·정렬 뷰, 원본 URL로 기존 행 조회 후 조회수만 갱신, 중복 행 아카이브, 404/403 등에 대한 연결·DB 재검증 흐름
- 파이프라인·태스크: 중복 감지(COMPLETED만 조회수 증가, FAILED는 재처리), 완료 중복 시 노션 동기화 및 응답 status 구분, Shorts → save_link_only_task(카테고리 쇼츠), SAVE_ONLY Celery 재시도·최종 실패 처리
- YouTube: Shorts URL 판별
- 지식 저장소: hit_count, 사용자·video_id 기준 최근 지식 조회, 조회수 증가
- AI: 청크·개요 프롬프트 보강, full_summary 짧을 때 보강 호출, VideoOverview·graph_state 정리
- 테스트: Notion·연결·knowledge_tasks 중복·조회수 관련 단위 테스트